### PR TITLE
Point buy support

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,9 @@
     "react-dom": "^15.5.4"
   },
   "devDependencies": {
-    "react-scripts": "0.9.5"
+    "enzyme": "^2.8.2",
+    "react-scripts": "0.9.5",
+    "react-test-renderer": "^15.5.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import './App.css';
+import {StatSelector} from './stat-selector';
 
 class App extends Component {
   state = {data: ":("};
@@ -15,7 +16,7 @@ class App extends Component {
     return (
       <div className="App">
         <div className="App-header">
-          <h2>{this.state.data}</h2>
+          <StatSelector name="STR"/>
         </div>
       </div>
     );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import './App.css';
-import {StatSelector} from './stat-selector';
+import {PointBuyManager} from './stat-selector';
 
 class App extends Component {
   state = {data: ":("};
@@ -16,7 +16,7 @@ class App extends Component {
     return (
       <div className="App">
         <div className="App-header">
-          <StatSelector name="STR"/>
+          <PointBuyManager />
         </div>
       </div>
     );

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-});

--- a/client/src/stat-selector.css
+++ b/client/src/stat-selector.css
@@ -1,0 +1,21 @@
+button:disabled {
+  opacity: 0.75;
+}
+
+.stat-selector-textbox {
+  margin-right: 10px;
+}
+
+.pb-mgr-availpts-negative {
+  color: red;
+  font-weight: bold;
+}
+
+.pb-mgr-availpts-zero {
+  color: limegreen;
+  font-weight: bold;
+}
+
+.pb-mgr-availpts-positive {
+
+}

--- a/client/src/stat-selector.js
+++ b/client/src/stat-selector.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-
+import './stat-selector.css';
  /*
   * Helper class for point buy.
   */
@@ -18,7 +18,6 @@ export class StatSelector extends Component {
     };
     if(isIncrementing ? this.props.score >= this.props.maxScore : this.props.score <= this.props.minScore ) {
       opts['disabled'] = 'true';
-      opts['style']['opacity'] = '0.75';
     }
     return opts;
   }
@@ -26,7 +25,7 @@ export class StatSelector extends Component {
   render() {
     return (
       <div>
-        <text style={{marginRight: "10px"}}>{this.props.name}: {this.props.score}</text>
+        <text className="stat-selector-textbox">{this.props.name}: {this.props.score}</text>
 
         <button {...this._buildButtonOpts(false)}>
           <text>-</text>
@@ -64,13 +63,14 @@ const pointBuyCosts = {
 export class PointBuyManager extends Component {
   constructor(props){
     super(props);
-    this.state = {
-      scores: {}
-    };
 
+    let scores = {}
     for(let stat in stats){
-      this.state.scores[stat] = this.props.defaultScore;
+      scores[stat] = this.props.defaultScore;
     }
+    this.state = {
+      scores: scores
+    };
 
   }
 
@@ -89,15 +89,12 @@ export class PointBuyManager extends Component {
   }
 
   _getPBStyle = (availablePoints) => {
-    let style = {}
-    if (availablePoints < 0) {
-      style['color'] = 'red';
-      style['fontWeight'] = 'bold';
-    } else if (availablePoints == 0) {
-      style['color'] = 'limegreen';
-      style['fontWeight'] = 'bold';
-    }
-    return style;
+    if(availablePoints < 0)
+      return 'pb-mgr-availpts-negative';
+    else if(availablePoints === 0)
+      return 'pb-mgr-availpts-zero';
+    else
+      return 'pb-mgr-availpts-positive';
   }
 
   _getSelectors() {
@@ -120,7 +117,7 @@ export class PointBuyManager extends Component {
       <div>
         <div style={{marginBottom: "10px"}}>
           <text>Available points: </text>
-          <text style={this._getPBStyle(availablePoints)}>{availablePoints}</text>
+          <text className={this._getPBStyle(availablePoints)}>{availablePoints}</text>
         </div>
         {this._getSelectors()}
       </div>

--- a/client/src/stat-selector.js
+++ b/client/src/stat-selector.js
@@ -3,6 +3,17 @@ import React, {Component} from 'react';
  const MIN_SCORE = 8;
  const MAX_SCORE = 15;
 
+ const pointBuyCosts = {
+   8:  0,
+   9:  1,
+   10: 2,
+   11: 3,
+   12: 4,
+   13: 5,
+   14: 7,
+   15: 9
+ };
+
  /*
   * Helper class for point buy.
   */
@@ -10,22 +21,34 @@ export class StatSelector extends Component {
   constructor(props){
     super(props);
     this.state = {
-        score: 10
-      };
+      score: 8
+    };
   }
 
   canDecrement = () => { return this.state.score > MIN_SCORE; }
   canIncrement = () => { return this.state.score < MAX_SCORE; }
 
   decrement = () => {
-    this.canDecrement() && this.setState({
-      score: this.state.score - 1
-    });
+    if(this.canDecrement()) {
+      this.props.onPointBuyValueChanged(
+        pointBuyCosts[this.state.score-1] - pointBuyCosts[this.state.score]
+      );
+      this.setState({
+        score: this.state.score - 1
+      });
+
+    }
+
   }
   increment = () => {
-    this.canIncrement() && this.setState({
-      score: this.state.score + 1
-    });
+    if(this.canIncrement()) {
+      this.props.onPointBuyValueChanged(
+        pointBuyCosts[this.state.score+1] - pointBuyCosts[this.state.score]
+      );
+      this.setState({
+        score: this.state.score + 1
+      });
+    }
   }
 
   _buildButtonOpts = (isIncrementing) => {
@@ -52,6 +75,59 @@ export class StatSelector extends Component {
         <button {...this._buildButtonOpts(true)}>
           <text>+</text>
         </button>
+
+      </div>
+    );
+  }
+}
+
+StatSelector.defaultProps = {
+  onPointBuyValueChanged: pointBuyDifference => {}
+}
+
+const stats = ["STR", "DEX", "CON", "INT", "WIS", "CHA"];
+
+export class PointBuyManager extends Component {
+  constructor(props){
+    super(props);
+    this.state = {
+      availablePoints: 27
+    };
+
+    this.selectors = []
+    for(let statName of stats) {
+      this.selectors.push(
+        <StatSelector
+        name={statName}
+        key={statName}
+        onPointBuyValueChanged={this._updatePointBuy}
+      />);
+    }
+  }
+
+  _updatePointBuy = (pointBuyDifference) => {
+    this.setState({
+      availablePoints: this.state.availablePoints - pointBuyDifference
+    });
+  }
+
+  _getPBStyle = () => {
+    let style = {}
+    if (this.state.availablePoints < 0) {
+      style['color'] = 'red';
+      style['fontWeight'] = 'bold';
+    }
+    return style;
+  }
+
+  render() {
+    return (
+      <div>
+        <div style={{marginBottom: "10px"}}>
+          <text>Available points: </text>
+          <text style={this._getPBStyle()}>{this.state.availablePoints}</text>
+        </div>
+        {this.selectors}
       </div>
     );
   }

--- a/client/src/stat-selector.js
+++ b/client/src/stat-selector.js
@@ -1,0 +1,58 @@
+import React, {Component} from 'react';
+
+ const MIN_SCORE = 8;
+ const MAX_SCORE = 15;
+
+ /*
+  * Helper class for point buy.
+  */
+export class StatSelector extends Component {
+  constructor(props){
+    super(props);
+    this.state = {
+        score: 10
+      };
+  }
+
+  canDecrement = () => { return this.state.score > MIN_SCORE; }
+  canIncrement = () => { return this.state.score < MAX_SCORE; }
+
+  decrement = () => {
+    this.canDecrement() && this.setState({
+      score: this.state.score - 1
+    });
+  }
+  increment = () => {
+    this.canIncrement() && this.setState({
+      score: this.state.score + 1
+    });
+  }
+
+  _buildButtonOpts = (isIncrementing) => {
+    let opts = {
+      "style": {backgroundColor: "white"},
+      "onClick": isIncrementing ? this.increment : this.decrement
+    };
+    if(isIncrementing ? !this.canIncrement() : !this.canDecrement() ) {
+      opts['disabled'] = 'true';
+      opts['style']['opacity'] = '0.75';
+    }
+    return opts;
+  }
+
+  render() {
+    return (
+      <div>
+        <text style={{marginRight: "10px"}}>{this.props.name}: {this.state.score}</text>
+
+        <button {...this._buildButtonOpts(false)}>
+          <text>-</text>
+        </button>
+
+        <button {...this._buildButtonOpts(true)}>
+          <text>+</text>
+        </button>
+      </div>
+    );
+  }
+}

--- a/client/src/stat-selector.test.js
+++ b/client/src/stat-selector.test.js
@@ -1,5 +1,6 @@
 import {
-  StatSelector
+  StatSelector,
+  PointBuyManager,
 } from './stat-selector';
 
 import { shallow } from 'enzyme';
@@ -18,23 +19,19 @@ describe('stat selector', () => {
     it('can instantiate', () => {
       expect(sut).toBeDefined();
     });
-    it('stat defaults to 10', () => {
-      expect(sut.state.score).toEqual(10);
+    it('stat defaults to 8', () => {
+      expect(sut.state.score).toEqual(8);
     });
   });
 
   describe('modifying score', () => {
-    it('can increment once', () => {
+    it('can increment and decrement', () => {
       sut.increment();
-      expect(sut.state.score).toEqual(11);
-    });
-    it('can decrement once', () => {
-      sut.decrement();
       expect(sut.state.score).toEqual(9);
+      sut.decrement();
+      expect(sut.state.score).toEqual(8);
     });
-
     it('enforces a minimum score of 8', () => {
-      expect(sut.canDecrement()).toEqual(true);
       while(sut.state.score != 8){
         sut.decrement();
       }
@@ -53,3 +50,18 @@ describe('stat selector', () => {
     })
   });
 });
+
+describe('point buy manager', () => {
+  let sut;
+  beforeEach(() => {
+    sut = shallow(
+      <PointBuyManager />
+    ).instance();
+  })
+  it('can instantiate', () => {
+    expect(sut).toBeDefined();
+  })
+  it('starts with 27 points available', () => {
+    expect(sut.state.availablePoints).toEqual(27);
+  })
+})

--- a/client/src/stat-selector.test.js
+++ b/client/src/stat-selector.test.js
@@ -126,4 +126,62 @@ describe('point buy manager', () => {
       expect(sut._getAvailablePoints()).toEqual(27-2*pointBuyCosts[statValue]);
     }
   })
+  describe('available points field styling', () => {
+    let availablePointsField;
+    beforeEach(() => {
+      sutWrapper = shallow(
+        <PointBuyManager />
+      );
+      sut = sutWrapper.instance();
+      availablePointsField = () => sutWrapper.find('text').at(1)
+    })
+    it('has pb-mgr-availpts-positive class when available points > 0', () => {
+      sutWrapper.setState({
+        scores: {
+          STR: 8,
+          DEX: 8,
+          CON: 8,
+          INT: 8,
+          WIS: 8,
+          CHA: 8
+        }
+      });
+      expect(sut._getAvailablePoints()).toBeGreaterThan(0);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-positive')).toBe(true);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-zero')).toBe(false);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-negative')).toBe(false);
+    })
+    it('has pb-mgr-availpts-zero class when available points == 0', () => {
+      sutWrapper.setState({
+        scores: {
+          STR: 15,
+          DEX: 15,
+          CON: 15,
+          INT: 8,
+          WIS: 8,
+          CHA: 8
+        }
+      });
+      expect(sut._getAvailablePoints()).toEqual(0);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-positive')).toBe(false);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-zero')).toBe(true);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-negative')).toBe(false);
+    });
+    it('has pb-mgr-availpts-negative class when available points < 0', () => {
+      sutWrapper.setState({
+        scores: {
+          STR: 15,
+          DEX: 15,
+          CON: 15,
+          INT: 15,
+          WIS: 15,
+          CHA: 15
+        }
+      });
+      expect(sut._getAvailablePoints()).toBeLessThan(0);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-positive')).toBe(false);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-zero')).toBe(false);
+      expect(availablePointsField().hasClass('pb-mgr-availpts-negative')).toBe(true);
+    })
+  })
 })

--- a/client/src/stat-selector.test.js
+++ b/client/src/stat-selector.test.js
@@ -1,0 +1,55 @@
+import {
+  StatSelector
+} from './stat-selector';
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+describe('stat selector', () => {
+  let sut;
+
+  beforeEach(() => {
+    sut = shallow(
+      <StatSelector />
+    ).instance();
+  })
+
+  describe('basic usage', () => {
+    it('can instantiate', () => {
+      expect(sut).toBeDefined();
+    });
+    it('stat defaults to 10', () => {
+      expect(sut.state.score).toEqual(10);
+    });
+  });
+
+  describe('modifying score', () => {
+    it('can increment once', () => {
+      sut.increment();
+      expect(sut.state.score).toEqual(11);
+    });
+    it('can decrement once', () => {
+      sut.decrement();
+      expect(sut.state.score).toEqual(9);
+    });
+
+    it('enforces a minimum score of 8', () => {
+      expect(sut.canDecrement()).toEqual(true);
+      while(sut.state.score != 8){
+        sut.decrement();
+      }
+      expect(sut.canDecrement()).toEqual(false);
+      sut.decrement();
+      expect(sut.state.score).toEqual(8);
+    })
+    it('enforces a maximum score of 15', () => {
+      expect(sut.canIncrement()).toEqual(true);
+      while(sut.state.score != 15){
+        sut.increment();
+      }
+      expect(sut.canIncrement()).toEqual(false);
+      sut.increment();
+      expect(sut.state.score).toEqual(15);
+    })
+  });
+});


### PR DESCRIPTION
Still needs a lot of styling love, but the core meat-and-potatoes is there.
- Component to manage point buy for a new character
- Increment/decrement buttons to adjust each score, which disable at min/max allowed values
- Points available to spend highlighted at top